### PR TITLE
allow non /symphony/ admin urls to work with the ui selector

### DIFF
--- a/assets/aui.selector.publish.js
+++ b/assets/aui.selector.publish.js
@@ -133,7 +133,7 @@
 			}
 
 			$.ajax({
-				url: Symphony.Context.get('root') + '/symphony/extension/association_ui_selector/get/',
+				url: Symphony.Context.get('symphony')  + '/extension/association_ui_selector/get/',
 				data: {
 					entry_id: entryId,
 					field_id: fieldId
@@ -159,7 +159,7 @@
 			id = item.data('value');
 
 			$.ajax({
-				url: Symphony.Context.get('root') + '/symphony/extension/association_ui_selector/query/',
+				url: Symphony.Context.get('symphony')  + '/extension/association_ui_selector/query/',
 				data: {
 					field_id: fieldId,
 					query: item.data('value'),
@@ -178,7 +178,7 @@
 
 		var fetchItem = function(entryId, fieldId, numeric, callback) {
 			$.ajax({
-				url: Symphony.Context.get('root') + '/symphony/extension/association_ui_selector/get/',
+				url: Symphony.Context.get('symphony')  + '/extension/association_ui_selector/get/',
 				data: {
 					entry_id: entryId,
 					field_id: fieldId
@@ -198,7 +198,7 @@
 
 		var fetchOptions = function(fieldId, query, limit, numeric, callback) {
 			$.ajax({
-				url: Symphony.Context.get('root') + '/symphony/extension/association_ui_selector/query/',
+				url: Symphony.Context.get('symphony')  + '/extension/association_ui_selector/query/',
 				data: {
 					field_id: fieldId,
 					query: encodeURIComponent(query),


### PR DESCRIPTION
/symphony/ is currently hard coded it should use the get context since it is now editable via config / initial setup.